### PR TITLE
adjust connection state after server version is set

### DIFF
--- a/IBKit/IBKit/Client/IBConnection.swift
+++ b/IBKit/IBKit/Client/IBConnection.swift
@@ -111,8 +111,8 @@ class IBConnection {
             else {
                 return
             }
-            self.state = .connectedToAPI
             self.delegate?.connection(self, didConnect: connectionTime, toServer: serverVersion)
+            self.state = .connectedToAPI
         } else if state == .connectedToAPI {
             self.delegate?.connection(self, didReceiveData: data)
         }


### PR DESCRIPTION
Many request encoding's are dependent on server version
Setting connection to API readings after server version & time is set