### PR TITLE
Throw error when trying to send message while socket not connected 

### DIFF
--- a/IBKit/IBKit/Client/IBClient.swift
+++ b/IBKit/IBKit/Client/IBClient.swift
@@ -117,14 +117,15 @@ open class IBClient: IBAnyClient, IBRequestWrapper {
 	}
 	
 	public func send(request: IBRequest) throws {
-	
+        guard let connection, connection.state == .connected else {
+            throw IBClientError.failedToSend("Client not connected")
+        }
 		let encoder = IBEncoder(serverVersion)
 		try encoder.encode(request)
 		let data = encoder.data
 		let dataWithLength = data.count.toBytes(size: 4) + data
 		
-		connection?.send(data: dataWithLength)
-
+		connection.send(data: dataWithLength)
 	}
 	
 	


### PR DESCRIPTION
When gateway or TWA is not running and you try to connect it fails. 
Moreover, you are able to send messages even tough there is no connection. 

Talking here connection to socket not API, as this is established later. 

This fix, throws error while trying to send message (from client) when we're not connected at all. 
Otherwise it freezes the app.