### PR TITLE
Fix issue when state is connected to the API

### DIFF
--- a/IBKit/IBKit/Client/IBClient.swift
+++ b/IBKit/IBKit/Client/IBClient.swift
@@ -117,7 +117,7 @@ open class IBClient: IBAnyClient, IBRequestWrapper {
 	}
 	
 	public func send(request: IBRequest) throws {
-        guard let connection, connection.state == .connected else {
+        guard let connection, [.connected, .connectedToAPI].contains(connection.state) else {
             throw IBClientError.failedToSend("Client not connected")
         }
 		let encoder = IBEncoder(serverVersion)


### PR DESCRIPTION
This pull request includes a change to the `IBClient` class in the `IBKit/IBKit/Client/IBClient.swift` file. The change updates the condition for checking the connection state before sending a request.

* Modified the `send` method to check if the connection state is either `.connected` or `.connectedToAPI` instead of just `.connected`. This ensures that requests can be sent when the client is connected to the API as well.

Which was broken due to my previous change... :( sorry!