### PR TITLE
Add trailing stop helper for IB order

### DIFF
--- a/IBKit/IBKit/Model/IBOrder+Ext.swift
+++ b/IBKit/IBKit/Model/IBOrder+Ext.swift
@@ -26,6 +26,19 @@ public extension IBOrder {
 	static func stopLimit(stop: Double, limit: Double, action: IBAction, quantity: Double,  contract: IBContract, account: String, validUntil tif: TimeInForce = .day, hidden: Bool = true, extendedTrading: Bool = false) -> IBOrder {
 		return IBOrder(contract: contract, action: action, totalQuantity: quantity, orderType: .STOP_LIMIT, lmtPrice: limit, auxPrice: stop, tif: tif, outsideRth: extendedTrading, hidden: hidden, account: account)
 	}
-		
+    
+    /// Creates a **Trailing Stop Order**
+    /// - Parameters:
+    ///   - stopOffset: The offset amount from the market price where the stop-loss should trail.
+    ///   - action: `.buy` or `.sell`
+    ///   - quantity: Number of shares/contracts
+    ///   - contract: The asset contract
+    ///   - account: IB account ID
+    ///   - tif: Time In Force (default `.day`)
+    ///   - hidden: Whether the order should be hidden
+    ///   - extendedTrading: Whether it should execute outside regular trading hours
+    static func trailingStop(stopOffset: Double, action: IBAction, quantity: Double, contract: IBContract, account: String, validUntil tif: TimeInForce = .day, hidden: Bool = true, extendedTrading: Bool = false) -> IBOrder {
+        IBOrder(contract: contract, action: action, totalQuantity: quantity, orderType: .TRAILING, lmtPrice: nil, auxPrice: stopOffset, tif: tif, outsideRth: extendedTrading, hidden: hidden, account: account)
+    }
 }
 


### PR DESCRIPTION
This pull request introduces a new method to the `IBOrder` extension in the `IBKit/IBKit/Model/IBOrder+Ext.swift` file. The most important change is the addition of a function to create a trailing stop order.

New functionality:

* Added `trailingStop` method to create a trailing stop order with parameters for stop offset, action, quantity, contract, account, time in force, hidden status, and extended trading hours.