### PR TITLE
Fix trailing stop helper methods

### DIFF
--- a/IBKit/IBKit/Model/IBOrder+Ext.swift
+++ b/IBKit/IBKit/Model/IBOrder+Ext.swift
@@ -29,7 +29,7 @@ public extension IBOrder {
     
     /// Creates a **Trailing Stop Order**
     /// - Parameters:
-    ///   - stopOffset: The offset amount from the market price where the stop-loss should trail.
+    ///   - stop: The stop price where the stop-loss should start the trail.
     ///   - action: `.buy` or `.sell`
     ///   - quantity: Number of shares/contracts
     ///   - contract: The asset contract
@@ -45,6 +45,31 @@ public extension IBOrder {
             orderType: .TRAILING,
             lmtPrice: limit,
             auxPrice: abs(limit - stop),
+            tif: tif,
+            outsideRth: extendedTrading,
+            hidden: hidden,
+            account: account
+        )
+    }
+    
+    /// Creates a **Trailing Stop Order**
+    /// - Parameters:
+    ///   - stopOffset: The offset amount from the market price where the stop-loss should trail.
+    ///   - action: `.buy` or `.sell`
+    ///   - quantity: Number of shares/contracts
+    ///   - contract: The asset contract
+    ///   - account: IB account ID
+    ///   - tif: Time In Force (default `.day`)
+    ///   - hidden: Whether the order should be hidden
+    ///   - extendedTrading: Whether it should execute outside regular trading hours
+    static func trailingStop(stopOffset: Double, limit: Double, action: IBAction, quantity: Double, contract: IBContract, account: String, validUntil tif: TimeInForce = .day, hidden: Bool = true, extendedTrading: Bool = false) -> IBOrder {
+        IBOrder(
+            contract: contract,
+            action: action,
+            totalQuantity: quantity,
+            orderType: .TRAILING,
+            lmtPrice: limit,
+            auxPrice: stopOffset,
             tif: tif,
             outsideRth: extendedTrading,
             hidden: hidden,

--- a/IBKit/IBKit/Model/IBOrder+Ext.swift
+++ b/IBKit/IBKit/Model/IBOrder+Ext.swift
@@ -37,8 +37,19 @@ public extension IBOrder {
     ///   - tif: Time In Force (default `.day`)
     ///   - hidden: Whether the order should be hidden
     ///   - extendedTrading: Whether it should execute outside regular trading hours
-    static func trailingStop(stopOffset: Double, action: IBAction, quantity: Double, contract: IBContract, account: String, validUntil tif: TimeInForce = .day, hidden: Bool = true, extendedTrading: Bool = false) -> IBOrder {
-        IBOrder(contract: contract, action: action, totalQuantity: quantity, orderType: .TRAILING, lmtPrice: nil, auxPrice: stopOffset, tif: tif, outsideRth: extendedTrading, hidden: hidden, account: account)
+    static func trailingStop(stop: Double, limit: Double, action: IBAction, quantity: Double, contract: IBContract, account: String, validUntil tif: TimeInForce = .day, hidden: Bool = true, extendedTrading: Bool = false) -> IBOrder {
+        IBOrder(
+            contract: contract,
+            action: action,
+            totalQuantity: quantity,
+            orderType: .TRAILING,
+            lmtPrice: limit,
+            auxPrice: abs(limit - stop),
+            tif: tif,
+            outsideRth: extendedTrading,
+            hidden: hidden,
+            account: account
+        )
     }
 }
 


### PR DESCRIPTION
This pull request includes changes to the `IBOrder` extension in the `IBKit/IBKit/Model/IBOrder+Ext.swift` file. The updates introduce a new method for creating trailing stop orders with a limit price and modify an existing method to include a limit price parameter.

Enhancements to trailing stop orders:

* Added a new static method `trailingStop` to create trailing stop orders with a limit price. This method includes parameters for stop price, limit price, action, quantity, contract, account, time in force, hidden status, and extended trading hours.
* Updated the existing static method `trailingStop` to include an additional parameter for the limit price, ensuring consistency with the new method. This method now takes parameters for stop offset, limit price, action, quantity, contract, account, time in force, hidden status, and extended trading hours.