### PR TITLE
yield is a reserved keyword in Swift 6+ due to the introduction of coroutines.

### DIFF
--- a/IBKit/IBKit/Responses/IBCommissionReport.swift
+++ b/IBKit/IBKit/Responses/IBCommissionReport.swift
@@ -14,7 +14,7 @@ public struct IBCommissionReport: IBResponse, IBEvent  {
 	public var commission: Double
 	public var currency: String
 	public var realizedPNL: Double?
-	public var yield: Double?
+	public var bondYield: Double?
 	public var yieldRedemptionDate: Date?
 
 	public init(from decoder: IBDecoder) throws {
@@ -24,9 +24,8 @@ public struct IBCommissionReport: IBResponse, IBEvent  {
 		commission = try container.decode(Double.self)
 		currency = try container.decode(String.self)
 		realizedPNL = try container.decodeOptional(Double.self)
-		yield = try container.decodeOptional(Double.self)
+        bondYield = try container.decodeOptional(Double.self)
 		yieldRedemptionDate = try container.decodeOptional(Date.self)
 	}
 	
 }
-


### PR DESCRIPTION
yield is a reserved keyword in Swift 6+ due to the introduction of coroutines.